### PR TITLE
fix: Revert some throwing ContractError to StdError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,10 +14,14 @@ version = "1.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-multi-test",
  "cw-storage-plus",
+ "cw-utils",
  "cw20",
  "schemars",
  "serde",
+ "test-case",
+ "thiserror",
 ]
 
 [[package]]

--- a/packages/asset/Cargo.toml
+++ b/packages/asset/Cargo.toml
@@ -5,14 +5,18 @@ authors = ["Apollo Dev"]
 edition = "2018"
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0", features = ["iterator"]}
-schemars = "0.8.5"
+cosmwasm-std = { version = "1.0.0", features = ["iterator"] }
+schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-cw20 = { version = "0.13.2" }
-cw-storage-plus = "0.13.2"
+cw20 = { version = "0.13.4" }
+cw-storage-plus = { version = "0.13.4" }
+thiserror = { version = "1.0.24" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }
+cw-multi-test = { version = "0.13.4" }
+cw-utils = { version = "0.13.4" }
+test-case = { version = "2.1.0" }
 
 [profile.release]
 overflow-checks = true

--- a/packages/asset/src/asset.rs
+++ b/packages/asset/src/asset.rs
@@ -1,4 +1,7 @@
-use crate::querier::{query_balance, query_token_balance, query_token_symbol};
+use crate::{
+    error::ContractError,
+    querier::{query_balance, query_token_balance, query_token_symbol},
+};
 use cosmwasm_std::{
     Addr, Api, Coin, CustomQuery, MessageInfo, QuerierWrapper, StdError, StdResult, Uint128,
 };
@@ -288,6 +291,7 @@ impl AssetInfo {
         }
     }
 
+    // TODO: Why a Result when it always return a value and handle all errors?
     pub fn from_str(api: &dyn Api, str: &str) -> StdResult<Self> {
         match api.addr_validate(str) {
             Ok(contract_addr) => Ok(Self::Token { contract_addr }),

--- a/packages/asset/src/error.rs
+++ b/packages/asset/src/error.rs
@@ -1,0 +1,17 @@
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("Unauthorized")]
+    Unauthorized {},
+
+    #[error("Native token balance mismatch between the argument and the transferred")]
+    TransferBalanceError {},
+
+    #[error("Cannot convert an non-native token to Addr.")]
+    NonNativeTokenConversion {},
+}

--- a/packages/asset/src/lib.rs
+++ b/packages/asset/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod asset;
 pub mod pair;
 pub mod querier;
+pub mod error;
 
 #[cfg(test)]
 mod tests;

--- a/packages/protocol/src/error.rs
+++ b/packages/protocol/src/error.rs
@@ -31,4 +31,15 @@ pub enum ContractError {
 
     #[error("Unknown reply operation")]
     UnknownReply,
+
+    #[error("Distribution schedule is empty")]
+    EmptyDistributionSchedule,
+
+    #[error("Invalid date ranges in distribution schedule")]
+    InvalidDistributionScheduleRanges,
+
+    #[error("Distribution schedule contains gaps or overlaps")]
+    OverlappedDistributionRanges
+
+
 }

--- a/packages/protocol/src/querier.rs
+++ b/packages/protocol/src/querier.rs
@@ -6,7 +6,7 @@ use cosmwasm_storage::to_length_prefixed;
 
 use crate::{
     factory::FactoryConfig,
-    legacy_strategy::msg::{StrategyConfig, StrategyInfo, UserInfo},
+    legacy_strategy::msg::{StrategyConfig, StrategyInfo, UserInfo}, error::ContractError,
 };
 
 ///Contains functions to query the store of Apollo contracts. This is to optimize gas usage when querying between contracts of Apollo Protocol.


### PR DESCRIPTION
Problem

Some functions called by outside the apollo-protocol doesnt expect the ContractError, instead they expect StdError.
Doing research, normally `execute()` method should return customize errors ( aka `ContractError`), while `query()` expect `StdError`. `instiantiate` could return ContractError or StdError.

Proposal:

For math conversion and storage access, change the error type to StdError.
For business logic on the smart contract, change StdError to custom COntractError.

Impact:

This should impact all contracts that consume apollo-protocol

